### PR TITLE
Add multiple advices of same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@ About CL-ADVICE
 ---------------
 This allows you to advise functions in Common Lisp. The main macros to use are
 `add-advice` and `defadvice`. `defadvice` expands into a call to `add-advice`.
+
+Arbitrary ammounts of advice can be added. This is achieved by wrapping up
+pre-existing advice within the new advice function. Because of this, we can think
+of advice like a stack. We add advice by pushing advice onto the stack, and by the
+same token we can pop advice from the stack. While a macro is included to list all
+advice, it isnt useful for reorganizing advice as every advice contains references
+to the advice below it on the stack. 
+
+ADD-ADVICE
+----------
 `add-advice` is used like so:
 
 `(add-advice (q-qualifier qualifier) name/db args body...)`
@@ -65,7 +75,8 @@ Advice can be defined with `defadvice`, like so:
   (format t "~&running after test~%"))
 ```
 
-Advice can be activated and deactivated with `deactivate-advice` and `activate-advice`.
+Advice can be activated and deactivated with `deactivate-advice` and
+`activate-advice`.
 
 Advice can be deleted with `delete-advice`.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ About CL-ADVICE
 This allows you to advise functions in Common Lisp. The main macros to use are
 `add-advice` and `defadvice`. `defadvice` expands into a call to `add-advice`.
 `add-advice` is used like so:
+
 `(add-advice (q-qualifier qualifier) name/db args body...)`
+
 It does the following:
+
 Define advice of type QUALIFIER for the function NAME. If an advisable-function
 object doesnt exist an error is signalled.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
 About CL-ADVICE
 ---------------
-This allows you to advise functions in Common Lisp. Please see docstrings for more information.
+This allows you to advise functions in Common Lisp. The main macros to use are
+`add-advice` and `defadvice`. `defadvice` expands into a call to `add-advice`.
+`add-advice` is used like so:
+`(add-advice (q-qualifier qualifier) name/db args body...)`
+It does the following:
+Define advice of type QUALIFIER for the function NAME. If an advisable-function
+object doesnt exist an error is signalled.
+
+Q-QUALIFIER denotes how to wrap pre-existing advice. It can be one of :before 
+:after :around or :base. :before and :after will run their advice before and after
+pre-existing advice respectively. :around will expose the local macros called 
+CALL-NEXT-ADVICE and CALL-NEXT-ADVICE-WITH-ARGS for usage in BODY. If a call to one
+of these macros does not occur in BODY then no further advice will be run. :base
+will overwrite pre-existing advice.
+
+QUALIFIER denotes what type of advice to create. It can have the value :before 
+:after or :around. These will run before, after or around the main function 
+respectively. :around advice will expose the local macros CALL-MAIN-FUNCTION and 
+CALL-MAIN-FUNCTION-WITH-ARGS. If calls to these macros dont appear in BODY the main
+function will not be called. If both Q-QUALIFIER and QUALIFIER are :around, the 
+local macros CALL-NEXT-ADVICE, CALL-NEXT-ADVICE-WITH-ARGS, CALL-MAIN-FUNCTION, and
+CALL-MAIN-FUNCTION-WITH-ARGS will be exposed to BODY. Advice should only ever call
+one of these macros to avoid running advice and the main function multiple times. 
+
+About :around advice - :around advice must be careful to return the correct value. 
+The final value of around advice is returned, so if one is doing something after a 
+call to CALL-MAIN-FUNCTION or CALL-NEXT-ADVICE, one must properly capture the 
+results of that call in order to return them. :before and :after advice does not 
+have this problem.
+
+NAME/DB denotes the name and database for advice to be stored in. It can be a 
+symbol, in which case it denotes the name of the function to advise and the 
+database defaults to *advice-hash-table*, or it can be a list, in which case the 
+car denotes the name of the function to advise and the cadr denotes the database.
+
+ARGS must either conform to the arglist of the function denoted by NAME, be of the 
+form (&rest rest), or be of the form (&ignore). If &ignore is specified then any 
+arguments will not be accessible to the advice. 
+
+BODY is the body of the advice. It may contain a docstring and declarations.
 
 How To
 ------
-Advice is defined with `defadvice`, like so:
+Advice can be defined with `defadvice`, like so:
 ```
 (defun test (a b) "add a and b" (+ a b))
 

--- a/README.md
+++ b/README.md
@@ -11,36 +11,37 @@ It does the following:
 Define advice of type QUALIFIER for the function NAME. If an advisable-function
 object doesnt exist an error is signalled.
 
-Q-QUALIFIER denotes how to wrap pre-existing advice. It can be one of :before 
-:after :around or :base. :before and :after will run their advice before and after
-pre-existing advice respectively. :around will expose the local macros called 
-CALL-NEXT-ADVICE and CALL-NEXT-ADVICE-WITH-ARGS for usage in BODY. If a call to one
-of these macros does not occur in BODY then no further advice will be run. :base
-will overwrite pre-existing advice.
+Q-QUALIFIER denotes how to wrap pre-existing advice. It can be one of `:before`
+`:after` `:around` or `:base`. `:before` and `:after` will run their advice before
+and after pre-existing advice respectively. `:around` will expose the local macros
+called `CALL-NEXT-ADVICE` and `CALL-NEXT-ADVICE-WITH-ARGS` for usage in BODY. If a
+call to one of these macros does not occur in BODY then no further advice will be
+run. `:base` will overwrite pre-existing advice.
 
-QUALIFIER denotes what type of advice to create. It can have the value :before 
-:after or :around. These will run before, after or around the main function 
-respectively. :around advice will expose the local macros CALL-MAIN-FUNCTION and 
-CALL-MAIN-FUNCTION-WITH-ARGS. If calls to these macros dont appear in BODY the main
-function will not be called. If both Q-QUALIFIER and QUALIFIER are :around, the 
-local macros CALL-NEXT-ADVICE, CALL-NEXT-ADVICE-WITH-ARGS, CALL-MAIN-FUNCTION, and
-CALL-MAIN-FUNCTION-WITH-ARGS will be exposed to BODY. Advice should only ever call
-one of these macros to avoid running advice and the main function multiple times. 
+QUALIFIER denotes what type of advice to create. It can have the value `:before` 
+`:after` or `:around`. These will run before, after or around the main function 
+respectively. `:around` advice will expose the local macros `CALL-MAIN-FUNCTION`
+and `CALL-MAIN-FUNCTION-WITH-ARGS`. If calls to these macros dont appear in BODY
+the main function will not be called. If both Q-QUALIFIER and QUALIFIER are
+`:around`, the local macros `CALL-NEXT-ADVICE`, `CALL-NEXT-ADVICE-WITH-ARGS`,
+`CALL-MAIN-FUNCTION`, and `CALL-MAIN-FUNCTION-WITH-ARGS` will be exposed to BODY.
+Advice should only ever call one of these macros to avoid running advice and the
+main function multiple times. 
 
-About :around advice - :around advice must be careful to return the correct value. 
-The final value of around advice is returned, so if one is doing something after a 
-call to CALL-MAIN-FUNCTION or CALL-NEXT-ADVICE, one must properly capture the 
-results of that call in order to return them. :before and :after advice does not 
-have this problem.
+About `:around` advice - `:around` advice must be careful to return the correct
+value. The final value of `:around` advice is returned, so if one is doing
+something after a call to `CALL-MAIN-FUNCTION` or `CALL-NEXT-ADVICE`, one must
+properly capture the results of that call in order to return them. `:before` and
+`:after` advice does not have this problem.
 
 NAME/DB denotes the name and database for advice to be stored in. It can be a 
 symbol, in which case it denotes the name of the function to advise and the 
-database defaults to *advice-hash-table*, or it can be a list, in which case the 
+database defaults to `*advice-hash-table*`, or it can be a list, in which case the 
 car denotes the name of the function to advise and the cadr denotes the database.
 
 ARGS must either conform to the arglist of the function denoted by NAME, be of the 
-form (&rest rest), or be of the form (&ignore). If &ignore is specified then any 
-arguments will not be accessible to the advice. 
+form `(&rest rest)`, or be of the form `(&ignore)`. If &ignore is specified then
+any arguments will not be accessible to the advice. 
 
 BODY is the body of the advice. It may contain a docstring and declarations.
 

--- a/cl-advice.lisp
+++ b/cl-advice.lisp
@@ -336,7 +336,7 @@ and CALL-MAIN-FUNCTION-WITH-ARGS for usage in BODY."
 
 (defmacro add-advice ((q-qualifier qualifier) name/db args &body body)
   "Define advice of type QUALIFIER for the function NAME. If an advisable-function
-object doesnt exist one will be created. 
+object doesnt exist an error is signalled.
 
 Q-QUALIFIER denotes how to wrap pre-existing advice. It can be one of :before 
 :after :around or :base. :before and :after will run their advice before and after

--- a/cl-advice.lisp
+++ b/cl-advice.lisp
@@ -70,6 +70,23 @@ otherwise evaluate BODY."
 (defparameter *advice-hash-table* (make-hash-table)
   "The default database for advisable-function objects")
 
+(add-advice (:before :before) test (&ignore)
+	    )
+
+(defun %add-advice (qualifiers-qualifier qualifier name generated-fn db)
+  (with-advisable-object (obj name db)
+    (case qualifier
+      (:before
+       (let ((b4 (advisable-function-before obj)))
+	 (if b4
+	     (setf (advisable-function-before obj)
+		   (lambda (&rest rest)
+		     (apply b4 rest)
+		     (apply generated-fn rest)))))))))
+
+(defmacro add-advice ((qualifiers-qualifier qualifier) name (args) &body body)
+  (with-advisable-object))
+
 (defun generate-defadvice-args-and-decls (arglist body)
   "Parse out argument list, docstring, and declarations for usage in defadvice"
   (let* ((ignore-args (equal (car arglist) '&ignore))

--- a/cl-advice.lisp
+++ b/cl-advice.lisp
@@ -90,6 +90,17 @@ otherwise evaluate BODY."
 		:symbol ,designator
 		:db ,db))))
 
+(defmacro with-advisable-object-advice ((fn-var obj-var qualifier designator
+					 &key (db '*advice-hash-table*))
+					&body body)
+  `(with-advisable-object (,obj-var ,designator :db ,db)
+     (let ((,fn-var ,(case qualifier
+		       (:before `((advisable-function-before ,obj-var)))
+		       (:around `((advisable-function-around ,obj-var)))
+		       (:after `((advisable-function-after ,obj-var)))
+		       (otherwise nil))))
+       ,@body)))
+
 (defmacro with-inner-advice ((var advice-function) &body body)
   `(let ((,var (funcall (or ,advice-function 'not) t)))
      ,@body))

--- a/package.lisp
+++ b/package.lisp
@@ -2,10 +2,23 @@
 
 (defpackage #:cl-advice
   (:use #:cl)
-  (:export #:symbol-not-fbound-error
+  (:export #:symbol-not-fbound-error ; conditions
 	   #:no-advisable-function-found-error
+	   ;; create advisable functions
+	   #:make-advisable
+	   #:defadvisable
+	   ;; advisable-function object access
 	   #:with-advisable-object
+	   #:with-advisable-object-advice
+	   #:with-inner-advice
+	   #:list-advice
+	   #:with-advice-list
+	   ;; advice creation
+	   #:add-advice
 	   #:defadvice
+	   ;; advice management
+	   #:pop-advice 
+	   #:advisable-function-p
 	   #:delete-advice
 	   #:activate-advice
 	   #:deactivate-advice


### PR DESCRIPTION
added the ability to define multiple pieces of advice of the same type - for example, two pieces of :before advice can be added to an object. 