### PR TITLE
ensure-advisable

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -2,15 +2,11 @@
 
 (defpackage #:cl-advice
   (:use #:cl)
-  (:export #:advisable-function-p
-           #:make-advisable
-	   #:make-unadvisable
-           #:advisable-lambda
-           #:defun-advisable
-
+  (:export #:advisable-lambda
            #:define-advisory-functions
            #:add-advice
            #:replace-advice
            #:list-advice
            #:remove-advice
-           #:remove-nth-advice))
+           #:remove-nth-advice
+	   #:remove-advice-all))

--- a/package.lisp
+++ b/package.lisp
@@ -9,4 +9,5 @@
            #:list-advice
            #:remove-advice
            #:remove-nth-advice
-	   #:remove-advice-all))
+	   #:remove-advice-all
+	   #:make-unadvisable))

--- a/tests.lisp
+++ b/tests.lisp
@@ -4,7 +4,8 @@
                 #:add-advice
                 #:remove-advice
                 #:replace-advice
-		#:remove-advice-all)
+		#:remove-advice-all
+		#:make-unadvisable)
   (:export :run-tests))
 
 (in-package :cl-advice-tests)
@@ -74,7 +75,18 @@
 
   (remove-advice-all 'main)
 
-  (is (string= (foutput 'main) "main.") "After make-unadvisable")
+  (is (string= (foutput 'main) "main.") "After remove-advice-all")
+
+  ;; all advices
+  (add-advice :before 'main 'before)
+  (add-advice :after 'main 'after)
+  (add-advice :around 'main 'around)
+
+  (is (string= (foutput 'main) "before.begin.main.end.after.") "All advices again")
+
+  (make-unadvisable 'main)
+
+  (is (string= (foutput 'main) "main.") "After remove-advice-all")
   )
 
 (defun main-args (x y)
@@ -134,7 +146,19 @@
 
   (remove-advice-all 'main-args)
 
-  (is (string= (foutput 'main-args 'x 'y) "main(X Y).") "After make-unadvisable"))
+  (is (string= (foutput 'main-args 'x 'y) "main(X Y).") "After remove-advice-all")
+
+  ;; all advices
+  (add-advice :before 'main-args 'before-args)
+  (add-advice :after 'main-args 'after-args)
+  (add-advice :around 'main-args 'around-args)
+
+  (is (string= (foutput 'main-args 'x 'y) "before(X Y).begin(X Y).main(X Y).end.after(X Y).") "All advices again")
+
+  (make-unadvisable 'main-args)
+
+  (is (string= (foutput 'main-args 'x 'y) "main(X Y).") "After make-unadvisable")
+  )
 
 (defun values-main (a b)
   (values a b))

--- a/tests.lisp
+++ b/tests.lisp
@@ -86,7 +86,7 @@
 
   (make-unadvisable 'main)
 
-  (is (string= (foutput 'main) "main.") "After remove-advice-all")
+  (is (string= (foutput 'main) "main.") "After make-unadvisable")
   )
 
 (defun main-args (x y)

--- a/tests.lisp
+++ b/tests.lisp
@@ -163,4 +163,6 @@
 
   
   (is (string= (foutput 'values-main 'a 'b) "Before(A B)After(A B)")
-      "Eval after adding before/after advice"))
+      "Eval after adding before/after advice")
+
+  (remove-advice-all 'values-main))


### PR DESCRIPTION
Hello, 

this is my take on how to implement implicit conversion to advisable functions.

It also unexports `make-advisable` and the like, as they are not relevant to the user anymore.

Let me know what you think.